### PR TITLE
Add number of open and help wanted issue to repo card

### DIFF
--- a/components/Repository.vue
+++ b/components/Repository.vue
@@ -91,6 +91,10 @@
           >{{ repo.license.name }}
         </span>
 
+        <span v-if="repo.open_help_wanted_issue_count">
+          {{ repo.open_help_wanted_issue_count }} issues need help
+        </span>
+
         <span>
           Requested
           <span

--- a/functions/check-repository/check-repository.js
+++ b/functions/check-repository/check-repository.js
@@ -47,6 +47,16 @@ const getPulls = async (repo) => {
   return pulls
 }
 
+const getOpenHelpWantedIssues = async (repo) => {
+  const { data: issues } = await octokit.issues.listForRepo({
+    owner: repo.owner.login,
+    repo: repo.name,
+    state: 'open',
+    labels: 'help wanted'
+  });
+  return issues;
+}
+
 const hasTopic = (topics) => {
   return topics.includes(keyTopic)
 }
@@ -79,6 +89,7 @@ exports.handler = async (event, context, callback) => {
     const { data: repo } = await getRepo(repoOwner, repoName)
     const topics = await getTopics(repo)
     const pulls = await getPulls(repo)
+    const openHelpWantedIssues = await getOpenHelpWantedIssues(repo);
 
     const body = {
       name: repo.name,
@@ -89,6 +100,7 @@ exports.handler = async (event, context, callback) => {
       topic: hasTopic(topics),
       tag_prs: hasTaggedPrs(pulls),
       recent_prs: false, // todo: return true if it has any PRs approved/merged in the last X days - probably won't do this
+      open_help_wanted_issue_count: openHelpWantedIssues.length,
       repo_updated_at: repo.updated_at,
       language: repo.language,
       license: repo.license,


### PR DESCRIPTION
Both adds the number of open and `help wanted`-labeled issues to the `repo` object - at `open_help_wanted_issue_count` - and displays it in the Repository component.

***

Closes #12