### PR TITLE
fix: change script to install missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "nuxt",
     "build": "nuxt build",
     "start": "nuxt start",
-    "pregenerate": "cd functions/check-repository && npm install",
+    "postinstall": "cd functions/check-repository && npm install",
     "generate": "nuxt generate",
     "lint:js": "eslint --ext .js,.vue --ignore-path .gitignore .",
     "lint": "npm run lint:js"


### PR DESCRIPTION
This PR changes the `pregenerate` script to `postinstall` to prevent the local development error.
