### PR TITLE
fix: Excluded from Hacktoberfest URL

### DIFF
--- a/functions/check-repository/check-repository.js
+++ b/functions/check-repository/check-repository.js
@@ -124,7 +124,7 @@ exports.handler = async (event, context, callback) => {
       forks: repo.forks,
       stargazers_count: repo.stargazers_count,
       banned: isBanned,
-      banned_url: isBanned ? bannedIssues.shift().url : null,
+      banned_url: isBanned ? bannedIssues.shift().html_url : null,
     }
 
     callback(null, {


### PR DESCRIPTION
Currently, if a repository is excluded from Hacktoberfest, the webpage displays the text `Excluded from Hacktoberfest` with a link to the relevant issue. However, that link was set with the `url` value, which returns the JSON package from the API endpoint. This PR changes the link to use the `html_url` value, which assigns the `github.com` link instead of the `api.github.com` link. 

### To test
On the live site:
1. Submit the url for an excluded repo: https://github.com/nhcarrigan/github-testing-playground
2. Click the "Excluded from Hacktoberfest" link on the results.
3. See the JSON data from the API endpoint. 

On a local instance of this PR:
1. Submit the url for an excluded repo: https://github.com/nhcarrigan/github-testing-playground
2. Click the "Excluded from Hacktoberfest" link on the results.
3. See the beautiful GitHub issue page.