### PR TITLE
fix: Mobile Responsiveness

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -7,12 +7,18 @@
   --color-vin-rouge: #9c4668;
   --color-waikawa-gray: #5b6987;
   --color-white: #ffffff;
+  --color-science-blue: #0366d6;
+  --color-alice-blue: #f1f8ff;
+  --color-rock-blue: #9daccc;
+  --color-mirage: #182030;
 
   --color: var(--color-waikawa-gray);
   --color-secondary: var(--color-vin-rouge);
   --color-tertiary: var(--color-bascay);
   --bg: var(--color-white);
   --bg-secondary: var(--color-black-squeeze);
+  --topic-primary: var(--color-science-blue);
+  --topic-secondary: var(--color-alice-blue);
 }
 
 .dark-mode {
@@ -21,6 +27,8 @@
   --color-tertiary: var(--color-white);
   --bg: var(--color-downriver);
   --bg-secondary: var(--color-bascay);
+  --topic-primary: var(--color-rock-blue);
+  --topic-secondary: var(--color-mirage);
 }
 
 body {

--- a/components/Announcement.vue
+++ b/components/Announcement.vue
@@ -13,7 +13,7 @@
 
 <style scoped>
 .Announcement__Link {
-  @apply block w-full py-4 pl-16 text-sm font-bold;
+  @apply block w-full py-4 px-10 text-sm font-bold;
   background-color: var(--color-lavender-rose);
   color: var(--color-downriver);
 }
@@ -22,11 +22,18 @@
   background-color: var(--color-morning-glory);
 }
 
-.Link__Button {
-  @apply bg-white py-2 px-4 mr-4 rounded uppercase;
-}
-
 .Announcement__Link:hover .Link__Text {
   @apply underline;
+}
+
+.Link__Button {
+  display: none;
+}
+
+@screen md {
+  .Link__Button {
+    display: initial;
+    @apply bg-white py-2 px-4 mr-4 rounded uppercase;
+  }
 }
 </style>

--- a/components/CheckRepository.vue
+++ b/components/CheckRepository.vue
@@ -3,8 +3,8 @@
     <div class="z-0 w-full h-without-header">
       <div class="flex flex-col items-center justify-end text-center h-3/4">
         <div class="w-1/2">
-          <h1 class="Title">Do they <strong>Hacktoberfest?</strong></h1>
-          <p class="Subtitle">
+          <h1 class="Title text-2xl md:text-4xl xl:text-6xl">Do they <strong>Hacktoberfest?</strong></h1>
+          <p class="Subtitle text-1xl md:text-2xl xl:text-3xl">
             Check if a project takes part in
             <strong>Hacktoberfest</strong> this year by looking up their
             repository URL.
@@ -12,23 +12,24 @@
         </div>
         <div class="w-4/5 mt-4 mb-8">
           <div v-if="isErrors" class="Errors">
-
-            <h2
-              class="Title"
-            >
-              {{errors.length > 1 ? 'Errors' : 'Error'}}
+            <h2 class="Title">
+              {{ errors.length > 1 ? 'Errors' : 'Error' }}
             </h2>
 
             <h3>
-              <p>Your request for repository <strong>{{ url }}</strong> failed!</p>
-              <p>Check the following {{errors.length > 1 ? 'errors' : 'error'}}:</p>
+              <p>
+                Your request for repository <strong>{{ url }}</strong> failed!
+              </p>
+              <p>
+                Check the following
+                {{ errors.length > 1 ? 'errors' : 'error' }}:
+              </p>
               <ul>
                 <li v-for="(error, index) in errors" :key="index">
                   <code>{{ error.message ? error.message : error }}</code>
                 </li>
               </ul>
             </h3>
-            
 
             <a
               href="#"
@@ -116,12 +117,12 @@
             <form class="flex" @submit.prevent="checkRepository()">
               <input
                 v-model="url"
-                class="Input"
+                class="Input text-sm md:text-1xl xl:text-3xl"
                 type="text"
                 placeholder="e.g. https://github.com/digitalocean/hacktoberfest"
                 :disabled="processing"
               />
-              <button :disabled="processing" class="Button">Do they?</button>
+              <button :disabled="processing" class="Button text-sm md:text-1xl xl:text-3xl">Do they?</button>
             </form>
           </div>
           <div>
@@ -241,8 +242,9 @@ export default {
 
 <style scoped>
 .Title {
-  @apply text-6xl font-bold leading-none mb-4;
+  @apply font-bold leading-none mb-4;
   color: var(--color-tertiary);
+  margin-top: 55px;
 }
 
 .Title strong {
@@ -250,7 +252,7 @@ export default {
 }
 
 .Subtitle {
-  @apply text-2xl leading-tight tracking-wide;
+  @apply leading-tight tracking-wide;
   color: var(--color-tertiary);
 }
 
@@ -275,7 +277,7 @@ export default {
 }
 
 .Input {
-  @apply bg-gray-100 text-3xl text-gray-800 pb-4 pt-5 pl-20 pr-4 rounded-l-lg w-full border-b-4 shadow-inner;
+  @apply bg-gray-100 text-gray-800 pb-4 pt-5 pl-20 pr-4 rounded-l-lg w-full border-b-4 shadow-inner;
 }
 
 .Input:focus {
@@ -284,7 +286,7 @@ export default {
 }
 
 .Button {
-  @apply px-8 rounded-r-lg w-1/4 text-3xl pb-4 pt-5 pl-4 pr-4 border-t border-b-4 border-r;
+  @apply px-8 rounded-r-lg w-1/4 pb-4 pt-5 pl-4 pr-4 border-t border-b-4 border-r;
   background-color: var(--color-tertiary);
   color: var(--bg);
   border-right-color: var(--color-tertiary);

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -16,48 +16,6 @@
         </nav>
       </div>
     </div>
-
-    <div class="Header__Mobile">
-      <div class="Mobile__Container">
-        <div class="Mobile__Card">
-          <div class="pt-5 pb-6 px-5 space-y-6">
-            <div class="flex items-center justify-between">
-              <div>
-                <Logo />
-              </div>
-              <div class="-mr-2">
-                <button type="button" class="Mobile__Button">
-                  <svg
-                    class="h-6 w-6"
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M6 18L18 6M6 6l12 12"
-                    />
-                  </svg>
-                </button>
-              </div>
-            </div>
-            <div>
-              <nav class="grid gap-y-8">
-                <a
-                  href="https://hacktoberfest.digitalocean.com"
-                  class="Mobile__Link"
-                >
-                  <div class="Link__Text">Click for the Official Site</div>
-                </a>
-              </nav>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
   </div>
 </template>
 
@@ -79,7 +37,7 @@
 }
 
 .Desktop__Menu {
-  @apply hidden uppercase;
+  @apply flex uppercase;
 }
 
 .Desktop__Link {
@@ -90,36 +48,6 @@
   @apply outline-none;
 }
 
-.Mobile__Container {
-  @apply rounded-lg shadow-lg;
-}
-
-.Mobile__Card {
-  @apply rounded-lg shadow-xs;
-}
-
-.Mobile__Button {
-  @apply inline-flex items-center justify-center p-2 rounded-md transition duration-150 ease-in-out;
-}
-
-.Mobile__Button:hover {
-}
-
-.Mobile__Button:focus {
-  @apply outline-none;
-}
-
-.Mobile__Link {
-  @apply -m-3 p-3 flex items-center rounded-md transition ease-in-out duration-150;
-}
-
-.Mobile__Link:hover {
-}
-
-.Mobile__Link .Link__Text {
-  @apply text-base leading-6 font-medium;
-}
-
 @screen sm {
   .Header__Desktop {
     @apply px-6;
@@ -127,10 +55,6 @@
 }
 
 @screen md {
-  .Header__Mobile {
-    @apply hidden;
-  }
-
   .Header__DesktopContainer {
     @apply justify-start;
   }

--- a/components/Logo.vue
+++ b/components/Logo.vue
@@ -1,7 +1,7 @@
 <template>
   <a href="#" class="flex">
     <img
-      class="h-20 w-auto sm:h-20"
+      class="h-20 w-auto sm:h-20 pr-2"
       src="~/assets/images/Icon.svg"
       alt="Hacktoberfest"
     />

--- a/components/Repository.vue
+++ b/components/Repository.vue
@@ -30,7 +30,7 @@
           <a :href="repo.url">{{ repo.long_name || repo.name }}</a>
         </h3>
       </div>
-      <div class="flex Repository__Row">
+      <div class="Repository__Row">
         <div class="flex-initial pr-10">
           {{ repo.description }}
           <ul v-if="theyHacktoberfest" class="mt-2 ml-8 list-disc">
@@ -67,6 +67,7 @@
 
       <div v-if="repo.topics" class="Repository__Row">
         <a
+          class="Topic"
           v-for="(topic, index) in repo.topics"
           :key="index"
           :href="`https://github.com/topics/${topic}`"
@@ -75,7 +76,7 @@
         </a>
       </div>
 
-      <div class="flex space-x-10 text-sm Repository__Row">
+      <div class="space-x-10 text-sm Repository__Row Repository__Info">
         <span v-if="repo.language">
           <span
             v-if="colors[repo.language]"
@@ -228,5 +229,26 @@ export default {
 
 .Repository__Row code {
   @apply border px-1;
+}
+
+.Repository__Info {
+  display: none;
+}
+
+.Topic {
+  background-color: var(--topic-secondary);
+  box-shadow: inset 0 0 0 1px var(--topic-primary);
+  margin-right: 5px;
+  padding: 0px 10px;
+  border-radius: 50px;
+}
+
+@screen md {
+  .Repository__Info {
+    display: flex;
+  }
+  .Repository__Row {
+    @apply flex;
+  }
 }
 </style>


### PR DESCRIPTION
This PR will address the mobile responsiveness, in relation to #15. 

Fixes:
- [X] Title text too large
- [X] Title overlaps with header (I fixed this with a hard-coded margin, which doesn't seem to impact the desktop display)
- [X] Repository card too wide
- [X] Topic tags styled to reflect GitHub

Repository card is fixed by removing the `flex` on smaller screens and allowing the buttons to size inward, and hiding the information (e.g. language, PRs, forks) on smaller screens. 