### PR TITLE
Added another installation step and fixed a typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ npm install netlify-cli -g
 
 You need to create a GitHub Personal Access Token to be able to access the GitHub API from your local environment.
 
-[Follow the documentation](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) and don't remember to copy the token before you leave the page (or you'll need to make two).
+[Follow the documentation](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) and don't forget to copy the token before you leave the page (or you'll need to make two).
 
 It ***ONLY*** needs the `public_repo` scope. Adding more scopes could be a security risk.
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ You need to create a GitHub Personal Access Token to be able to access the GitHu
 
 It ***ONLY*** needs the `public_repo` scope. Adding more scopes could be a security risk.
 
+### Install Packages
+
+To install the packages required for this project, run:
+
+```bash
+npm install
+```
+
 ### Configure Environment
 
 Create a `.env` file and add your access token to it as shown here.


### PR DESCRIPTION
The README didn't contain the instruction to run `npm install` so I've added this.

Also, there was a confusing part of the GitHub access token telling the user `don't remember to copy the access token`