### PR TITLE
Allow user/repo format

### DIFF
--- a/components/CheckRepository.vue
+++ b/components/CheckRepository.vue
@@ -204,8 +204,13 @@ export default {
       }
 
       var isGitHub = new RegExp("https?:\\/\\/(.+?\\.)?github\\.com(\\/[A-Za-z0-9\\-\\._~:\\/\\?#\\[\\]@!$&'\\(\\)\\*\\+,;\\=]*)?");
+      var isGitHubRepo = new RegExp('[a-zA-Z]+\/[a-zA-Z]+');
 
-      if (false === isGitHub.test(this.url)) {
+      if(!isGitHub.test(this.url) && isGitHubRepo.test(this.url)) {
+        this.url = `https://github.com/${this.url}`;
+      }
+
+      if (false === isGitHub.test(this.url) && !isGitHubRepo.test(this.url)) {
         return this.errors.push({message: 'Please use a GitHub url to check.'});
       }
 

--- a/components/CheckRepository.vue
+++ b/components/CheckRepository.vue
@@ -203,15 +203,15 @@ export default {
         return this.errors.push({message: 'Please enter a url to check.'});
       }
 
-      var isGitHub = new RegExp("https?:\\/\\/(.+?\\.)?github\\.com(\\/[A-Za-z0-9\\-\\._~:\\/\\?#\\[\\]@!$&'\\(\\)\\*\\+,;\\=]*)?");
-      var isGitHubRepo = new RegExp("[a-zA-Z]+\/[a-zA-Z]+");
+      var isGithub = new RegExp("https?:\\/\\/(.+?\\.)?github\\.com(\\/[A-Za-z0-9\\-\\._~:\\/\\?#\\[\\]@!$&'\\(\\)\\*\\+,;\\=]*)?");
+      var isGithubRepo = new RegExp("[a-zA-Z]+\/[a-zA-Z]+");
 
-      if(!isGitHub.test(this.url) && isGitHubRepo.test(this.url)) {
+      if(!isGithub.test(this.url)) {
         this.url = `https://github.com/${this.url}`;
       }
 
-      if (false === isGitHub.test(this.url) && !isGitHubRepo.test(this.url)) {
-        return this.errors.push({message: 'Please use a GitHub url to check.'});
+      if (!isGithub.test(this.url) && !isGithubRepo.test(this.url)) {
+        return this.errors.push({ message: 'Please use a GitHub url to check.' });
       }
 
       this.processing = true

--- a/components/CheckRepository.vue
+++ b/components/CheckRepository.vue
@@ -204,7 +204,7 @@ export default {
       }
 
       var isGitHub = new RegExp("https?:\\/\\/(.+?\\.)?github\\.com(\\/[A-Za-z0-9\\-\\._~:\\/\\?#\\[\\]@!$&'\\(\\)\\*\\+,;\\=]*)?");
-      var isGitHubRepo = new RegExp('[a-zA-Z]+\/[a-zA-Z]+');
+      var isGitHubRepo = new RegExp("[a-zA-Z]+\/[a-zA-Z]+");
 
       if(!isGitHub.test(this.url) && isGitHubRepo.test(this.url)) {
         this.url = `https://github.com/${this.url}`;


### PR DESCRIPTION
This PR allows validation to also work on user/repo format such as `digitalocean/hacktoberfest`.
I have tested this PR and it works perfectly!

This PR implements #46 