### PR TITLE
Fix background colour issue in darkmode for Lang Picker

### DIFF
--- a/components/LangPicker.vue
+++ b/components/LangPicker.vue
@@ -20,7 +20,7 @@
       id="lang"
       v-model="selectedLocale"
       name="lang"
-      class="uppercase lang-dropdown"
+      class="uppercase LangPicker__Dropdown"
       @change="switchLocale(selectedLocale)"
     >
       <option :value="currentLocale.code" selected="selected">
@@ -70,7 +70,9 @@ export default {
 .lang-svg {
   margin-top: 2px;
 }
-.lang-dropdown {
+
+.LangPicker__Dropdown {
   margin-top: 1px;
+  background-color: transparent;
 }
 </style>


### PR DESCRIPTION
Fix background colour issue in dark mode for Lang Picker. Previously the background colour remained unchanged when switching to dark mode. Fixes this issue by adding `background-color: transparent` 
## Related Issue:

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #67
